### PR TITLE
Update fabric.mod.json for Fabric API name space

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   ],
   "depends": {
     "java": ">=17",
-    "fabric": "*",
+    "fabric-api": "*",
     "minecraft": ">=1.20.1",
     "azurelib": ">=1.0.15",
     "fromanotherlibrary": ">=1.0.1"


### PR DESCRIPTION
Fixes issue with it showing `fabric` as missing, as 1.19.2, Fabric API changed it's name space to fabric-api so that gives users a better clue to what they are moving! See https://fabricmc.net/wiki/tutorial:setup#mod_setup